### PR TITLE
Suggest to use roxytest for testing documentation

### DIFF
--- a/ehep/DESCRIPTION
+++ b/ehep/DESCRIPTION
@@ -22,6 +22,14 @@ Imports:
     truncnorm
 Suggests: 
     testthat (>= 3.0.0)
+    roxytest
+Roxygen: list(roclets = c("namespace", "rd", 
+                          "roxytest::testthat_roclet",
+                          "roxytest::param_roclet",
+                          "roxytest::return_roclet",
+                          "roxytest::examples_roclet"
+                          )
+              )
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true

--- a/ehep/util/setup.R
+++ b/ehep/util/setup.R
@@ -13,6 +13,7 @@ packages = c(
   "truncnorm",
   "tibble",
   "testthat",
+  "roxytest",
   #------------
   "readr",
   "tidyr"


### PR DESCRIPTION
https://cran.r-project.org/web/packages/roxytest/vignettes/introduction.html
with this tool we can identify missing documents and later on test examples 
if you run it roxygen it will output like this

```
 * Function 'CheckInputExcelFileFormat()' with title 'Perform Sanity Checks On Input Excel File': 
    - Missing @param's: scenarioSheet, seasonalityOffsetsSheet
    + Too many @param's: scenariosSheet
* Function '.fRatesRibbonPlot()' with title 'Plot Fertility Rates Statistics As Ribbon Plot': 
    - Missing @param's: df
    + Too many @param's: results
...

```