### PR TITLE
Don't load a population rates sheet during initialization.

### DIFF
--- a/ehep/R/ehep_population_config.R
+++ b/ehep/R/ehep_population_config.R
@@ -80,8 +80,7 @@ InitializePopulation <- function(){
 
   GPE$initialPopulation <- loadInitialPopulation()
 
-  GPE$populationChangeParameters <-
-    loadPopulationChangeParameters()
+  GPE$populationChangeParameters <- NULL
 
   return(invisible(NULL))
 }

--- a/ehep/tests/testthat/test-ehep_population_config.R
+++ b/ehep/tests/testthat/test-ehep_population_config.R
@@ -66,7 +66,11 @@ test_that("Population configuration: InitializePopulation()", {
 
   testthat::expect_true(e$globalConfigLoaded)
   testthat::expect_true(!is.null(e$initialPopulation))
-  testthat::expect_true(!is.null(e$populationChangeParameters))
+
+  # 7/30/2022 Population change parameters are now loaded when an experiment
+  # suite is started with the SaveBaseSettings() function, based on the
+  # particular scenario being run.
+  testthat::expect_true(is.null(e$populationChangeParameters))
 
   testthat::expect_true(.validInitPopulation(e$initialPopulation))
 })


### PR DESCRIPTION
This is the first small step towards integrating the new population rates format.

In this step we turn off the initial read of the PopValues sheet. This could have been done a while ago, because the population rates sheet for a given Scenario is defined in the Scenario record, and is loaded when the Scenario is actually run.