### PR TITLE
Bumping version number to force API reference  rebuild.

### DIFF
--- a/pacehrh/DESCRIPTION
+++ b/pacehrh/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: pacehrh
 Title: Population-Aware Capacity Estimator for Human Resources for Health
-Version: 1.0.7
+Version: 1.0.8
 Author: Charles Eliot, Brittany Hagedorn
 Maintainer: Charles Eliot <charles.eliot@gatesfoundation.org>
 Description: This package models the healthcare needs of a given population so you


### PR DESCRIPTION
Issue #222 was addressed in an earlier PRs (PR #268), but the version number wasn't bumped so the PR didn't kick off a documentation rebuild. 